### PR TITLE
bootstrap-sass のバージョンを最新の状態に

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'coffee-rails',   '4.2.2'
 gem 'jquery-rails',   '4.3.1'
 gem 'turbolinks',     '5.0.1'
 gem 'jbuilder',       '2.7.0'
-gem 'bootstrap-sass', '3.3.7'
+gem 'bootstrap-sass', '3.4.1'
 
 group :development, :test do
   gem 'sqlite3', '1.3.13'


### PR DESCRIPTION
## 背景
#7 の対応

## やったこと
- gem: `bootstrap-sass` のバージョンを [CVE-2019-8331](https://nvd.nist.gov/vuln/detail/CVE-2019-8331) で確認し，パッチの適用された最新状態に変更