### PR TITLE
Chapter11

### DIFF
--- a/app/assets/javascripts/account_activations.coffee
+++ b/app/assets/javascripts/account_activations.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/account_activations.scss
+++ b/app/assets/stylesheets/account_activations.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the AccountActivations controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,0 +1,2 @@
+class AccountActivationsController < ApplicationController
+end

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -1,2 +1,15 @@
 class AccountActivationsController < ApplicationController
+  def edit
+    user = User.find_by(email: params[:email])
+    if user && !user.activated? && user.authenticated?(:activation, params[:id])
+      user.update_attribute(:activated,    true)
+      user.update_attribute(:activated_at, Time.zone.now)
+      log_in user
+      flash[:success] = "Account activated!"
+      redirect_to user
+    else
+      flash[:danger] = "Invalid activation link"
+      redirect_to root_url
+    end
+  end
 end

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -2,8 +2,7 @@ class AccountActivationsController < ApplicationController
   def edit
     user = User.find_by(email: params[:email])
     if user && !user.activated? && user.authenticated?(:activation, params[:id])
-      user.update_attribute(:activated,    true)
-      user.update_attribute(:activated_at, Time.zone.now)
+      user.activate
       log_in user
       flash[:success] = "Account activated!"
       redirect_to user

--- a/app/controllers/account_activations_controller.rb
+++ b/app/controllers/account_activations_controller.rb
@@ -2,7 +2,8 @@ class AccountActivationsController < ApplicationController
   def edit
     user = User.find_by(email: params[:email])
     if user && !user.activated? && user.authenticated?(:activation, params[:id])
-      user.activate
+      now = Time.zone.now
+      user.activate(now)
       log_in user
       flash[:success] = "Account activated!"
       redirect_to user

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -5,9 +5,16 @@ class SessionsController < ApplicationController
   def create
     @user = User.find_by(email: params[:session][:email].downcase)
     if @user && @user.authenticate(params[:session][:password])
-      log_in @user
-      params[:session][:remember_me] == '1' ? remember(@user):forget(@user)
-      redirect_back_or @user
+      if @user.activated?
+        log_in @user
+        params[:session][:remember_me] == '1' ? remember(@user):forget(@user)
+        redirect_back_or @user
+      else
+        message  = "Account not activated."
+        message += "Check your email for the activation link."
+        flash[:warning] = message
+        redirect_to root_url
+      end
     else
       flash.now[:danger] = 'Invalid email/password combination'
       render 'new'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,11 +4,12 @@ class UsersController < ApplicationController
   before_action :admin_user,     only: :destroy
 
   def index
-    @users = User.paginate(page: params[:page])
+    @users = User.where(activated: true).paginate(page: params[:page])
   end
 
   def show
     @user = User.find(params[:id])
+    redirect_to root_url and return unless @user.activated?
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      UserMailer.account_activation(@user).deliver_now
+      @user.send_activation_email
       flash[:info] = "Please check your email to activate your account."
       redirect_to root_url
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,9 +18,9 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      log_in @user
-      flash[:success] = "Welcome to the Sample App!"
-      redirect_to @user
+      UserMailer.account_activation(@user).deliver_now
+      flash[:info] = "Please check your email to activate your account."
+      redirect_to root_url
     else
       render 'new'
     end

--- a/app/helpers/account_activations_helper.rb
+++ b/app/helpers/account_activations_helper.rb
@@ -1,0 +1,2 @@
+module AccountActivationsHelper
+end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -20,7 +20,7 @@ module SessionsHelper
       @current_user ||= User.find_by(id: user_id)
     elsif (user_id = cookies.signed[:user_id])
       user = User.find_by(id: user_id)
-      if user && user.authenticated?(cookies[:remember_token])
+      if user && user.authenticated?(:remember, cookies[:remember_token])
         log_in user
         @current_user = user
       end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: 'noreply@example.com'
   layout 'mailer'
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,24 @@
+class UserMailer < ApplicationMailer
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.account_activation.subject
+  #
+  def account_activation
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+
+  # Subject can be set in your I18n file at config/locales/en.yml
+  # with the following lookup:
+  #
+  #   en.user_mailer.password_reset.subject
+  #
+  def password_reset
+    @greeting = "Hi"
+
+    mail to: "to@example.org"
+  end
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,24 +1,10 @@
 class UserMailer < ApplicationMailer
-
-  # Subject can be set in your I18n file at config/locales/en.yml
-  # with the following lookup:
-  #
-  #   en.user_mailer.account_activation.subject
-  #
-  def account_activation
-    @greeting = "Hi"
-
-    mail to: "to@example.org"
+  def account_activation(user)
+    @user = user
+    mail to: user.email, subject: "Account activation"
   end
 
-  # Subject can be set in your I18n file at config/locales/en.yml
-  # with the following lookup:
-  #
-  #   en.user_mailer.password_reset.subject
-  #
   def password_reset
-    @greeting = "Hi"
-
-    mail to: "to@example.org"
+    # TODO: パスワード再設定の実装
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,8 +40,8 @@ class User < ApplicationRecord
     update_attribute(:remember_digest, nil)
   end
 
-  def activate
-    update_attributes(activated: true, activated_at: Time.zone.now)
+  def activate(now = Time.zone.now)
+    update_attributes(activated: true, activated_at: now)
   end
 
   def send_activation_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,9 +28,11 @@ class User < ApplicationRecord
     update_attribute(:remember_digest, User.digest(remember_token))
   end
 
-  def authenticated?(remember_token)
-    return false if remember_digest.nil?
-    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+  # トークンがダイジェストと一致したらtrueを返す
+  def authenticated?(attribute, token)
+    digest = send("#{attribute}_digest")
+    return false if digest.nil?
+    BCrypt::Password.new(digest).is_password?(token)
   end
 
   # ユーザーのログイン情報を破棄する

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,15 @@ class User < ApplicationRecord
     update_attribute(:remember_digest, nil)
   end
 
+  def activate
+    update_attribute(:activated, true)
+    update_attribute(:activated_at, Time.zone.now)
+  end
+
+  def send_activation_email
+    UserMailer.account_activation(self).deliver_now
+  end
+
   private
 
     def downcase_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@ class User < ApplicationRecord
 
   # トークンがダイジェストと一致したらtrueを返す
   def authenticated?(attribute, token)
-    digest = send("#{attribute}_digest")
+    digest = public_send("#{attribute}_digest")
     return false if digest.nil?
     BCrypt::Password.new(digest).is_password?(token)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
-  attr_accessor :remember_token
-  before_save { email.downcase! }
+  attr_accessor :remember_token, :activation_token
+  before_save   :downcase_email
+  before_create :create_activation_digest
   validates :name,  presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :email, presence: true, length: { maximum: 255 },
@@ -36,4 +37,15 @@ class User < ApplicationRecord
   def forget
     update_attribute(:remember_digest, nil)
   end
+
+  private
+
+    def downcase_email
+      self.email = self.email.downcase
+    end
+
+    def create_activation_digest
+      self.activation_token  = User.new_token
+      self.activation_digest = User.digest(activation_token)
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,7 +40,7 @@ class User < ApplicationRecord
     update_attribute(:remember_digest, nil)
   end
 
-  def activate(now = Time.zone.now)
+  def activate(now)
     update_attributes(activated: true, activated_at: now)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,7 @@ class User < ApplicationRecord
   private
 
     def downcase_email
-      self.email = self.email.downcase
+      self.email.downcase!
     end
 
     def create_activation_digest

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,8 +41,7 @@ class User < ApplicationRecord
   end
 
   def activate
-    update_attribute(:activated, true)
-    update_attribute(:activated_at, Time.zone.now)
+    update_attributes(activated: true, activated_at: Time.zone.now)
   end
 
   def send_activation_email

--- a/app/views/user_mailer/account_activation.html.erb
+++ b/app/views/user_mailer/account_activation.html.erb
@@ -1,0 +1,5 @@
+<h1>User#account_activation</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/user_mailer/account_activation.html.erb
+</p>

--- a/app/views/user_mailer/account_activation.html.erb
+++ b/app/views/user_mailer/account_activation.html.erb
@@ -1,5 +1,15 @@
-<h1>User#account_activation</h1>
+<h1>Sample App</h1>
+
+<p>Hi <%= @user.name %>,</p>
 
 <p>
-  <%= @greeting %>, find me in app/views/user_mailer/account_activation.html.erb
+Welcome to the Sample App! Click on the link below to activate your account:
 </p>
+
+<%=
+  link_to "Activate",
+  edit_account_activation_url(
+    @user.activation_token,
+    email: @user.email
+  )
+%>

--- a/app/views/user_mailer/account_activation.text.erb
+++ b/app/views/user_mailer/account_activation.text.erb
@@ -1,0 +1,3 @@
+User#account_activation
+
+<%= @greeting %>, find me in app/views/user_mailer/account_activation.text.erb

--- a/app/views/user_mailer/account_activation.text.erb
+++ b/app/views/user_mailer/account_activation.text.erb
@@ -1,3 +1,5 @@
-User#account_activation
+Hi <%= @user.name %>,
 
-<%= @greeting %>, find me in app/views/user_mailer/account_activation.text.erb
+Welcome to the Sample App! Click on the link below to activate your account:
+
+<%= edit_account_activation_url(@user.activation_token, email: @user.email) %>

--- a/app/views/user_mailer/password_reset.html.erb
+++ b/app/views/user_mailer/password_reset.html.erb
@@ -1,0 +1,5 @@
+<h1>User#password_reset</h1>
+
+<p>
+  <%= @greeting %>, find me in app/views/user_mailer/password_reset.html.erb
+</p>

--- a/app/views/user_mailer/password_reset.text.erb
+++ b/app/views/user_mailer/password_reset.text.erb
@@ -1,0 +1,3 @@
+User#password_reset
+
+<%= @greeting %>, find me in app/views/user_mailer/password_reset.text.erb

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -31,7 +31,11 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :test
+  host = 'localhost:3000' # ここをコピペすると失敗します。自分の環境に合わせてください。
+  config.action_mailer.default_url_options = { host: host, protocol: 'http' }
+
 
   config.action_mailer.perform_caching = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,7 @@ Rails.application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,5 @@ Rails.application.routes.draw do
   post '/login',   to: 'sessions#create'
   delete  '/logout',   to: 'sessions#destroy'
   resources :users
+  resources :account_activations, only: [:edit]
 end

--- a/db/migrate/20190823044115_add_activation_to_users.rb
+++ b/db/migrate/20190823044115_add_activation_to_users.rb
@@ -1,0 +1,7 @@
+class AddActivationToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :activation_digest, :string
+    add_column :users, :activated, :boolean
+    add_column :users, :activated_at, :datetime
+  end
+end

--- a/db/migrate/20190823044115_add_activation_to_users.rb
+++ b/db/migrate/20190823044115_add_activation_to_users.rb
@@ -1,7 +1,7 @@
 class AddActivationToUsers < ActiveRecord::Migration[5.2]
   def change
     add_column :users, :activation_digest, :string
-    add_column :users, :activated, :boolean
+    add_column :users, :activated, :boolean, default: false
     add_column :users, :activated_at, :datetime
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_19_155426) do
+ActiveRecord::Schema.define(version: 2019_08_23_044115) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -20,6 +20,9 @@ ActiveRecord::Schema.define(version: 2019_08_19_155426) do
     t.string "password_digest"
     t.string "remember_digest"
     t.boolean "admin", default: false
+    t.string "activation_digest"
+    t.boolean "activated", default: false
+    t.datetime "activated_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,9 @@ User.create!(
   email: "example@railstutorial.org",
   password:              "foobar",
   password_confirmation: "foobar",
-  admin: true
+  admin: true,
+  activated: true,
+  activated_at: Time.zone.now
 )
 
 99.times do |n|
@@ -14,6 +16,8 @@ User.create!(
     name:  name,
     email: email,
     password:              password,
-    password_confirmation: password
+    password_confirmation: password,
+    activated: true,
+    activated_at: Time.zone.now
   )
 end

--- a/test/controllers/account_activations_controller_test.rb
+++ b/test/controllers/account_activations_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AccountActivationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -3,25 +3,35 @@ michael:
   email: michael@example.com
   password_digest: <%= User.digest('password') %>
   admin: true
+  activated: true
+  activated_at: <%= time.zone.now %>
 
 archer:
   name:  Sterling Archer
   email: duchess@example.gov
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= time.zone.now %>
 
 lana:
   name:  Lana Kane
   email: hands@example.gov
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= time.zone.now %>
 
 malory:
   name:  Malory Archer
   email: boss@example.gov
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= time.zone.now %>
 
 <% 30.times do |n| %>
 user_<%= n %>:
   name:  <%= "User #{n}" %>
   email: <%= "user-#{n}@example.com" %>
   password_digest: <%= User.digest('password') %>
+  activated: true
+  activated_at: <%= time.zone.now %>
 <% end %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,28 +4,28 @@ michael:
   password_digest: <%= User.digest('password') %>
   admin: true
   activated: true
-  activated_at: <%= time.zone.now %>
+  activated_at: <%= Time.zone.now %>
 
 archer:
   name:  Sterling Archer
   email: duchess@example.gov
   password_digest: <%= User.digest('password') %>
   activated: true
-  activated_at: <%= time.zone.now %>
+  activated_at: <%= Time.zone.now %>
 
 lana:
   name:  Lana Kane
   email: hands@example.gov
   password_digest: <%= User.digest('password') %>
   activated: true
-  activated_at: <%= time.zone.now %>
+  activated_at: <%= Time.zone.now %>
 
 malory:
   name:  Malory Archer
   email: boss@example.gov
   password_digest: <%= User.digest('password') %>
   activated: true
-  activated_at: <%= time.zone.now %>
+  activated_at: <%= Time.zone.now %>
 
 <% 30.times do |n| %>
 user_<%= n %>:
@@ -33,5 +33,5 @@ user_<%= n %>:
   email: <%= "user-#{n}@example.com" %>
   password_digest: <%= User.digest('password') %>
   activated: true
-  activated_at: <%= time.zone.now %>
+  activated_at: <%= Time.zone.now %>
 <% end %>

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class UsersSignupTest < ActionDispatch::IntegrationTest
+  def setup
+    ActionMailer::Base.deliveries.clear
+  end
+
   test "invalid signup information" do
     get signup_path
     assert_no_difference 'User.count' do
@@ -19,7 +23,7 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     assert_select 'form[action="/signup"]'
   end
 
-  test "valid signup information" do
+  test "valid signup information with account activation" do
     get signup_path
     assert_difference 'User.count', 1 do
       post users_path, params: {
@@ -31,8 +35,23 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
         }
       }
     end
+    assert_equal 1, ActionMailer::Base.deliveries.size
+    user = assigns(:user)
+    assert_not user.activated?
+    # 有効化していない状態でログインしてみる
+    log_in_as(user)
+    assert_not is_logged_in?
+    # 有効化トークンが不正な場合
+    get edit_account_activation_path("invalid token", email: user.email)
+    assert_not is_logged_in?
+    # トークンは正しいがメールアドレスが無効な場合
+    get edit_account_activation_path(user.activation_token, email: 'wrong')
+    assert_not is_logged_in?
+    # 有効化トークンが正しい場合
+    get edit_account_activation_path(user.activation_token, email: user.email)
+    assert user.reload.activated?
     follow_redirect!
-    # assert_template 'users/show'
-    # assert is_logged_in?
+    assert_template 'users/show'
+    assert is_logged_in?
   end
 end

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -32,7 +32,7 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
       }
     end
     follow_redirect!
-    assert_template 'users/show'
-    assert is_logged_in?
+    # assert_template 'users/show'
+    # assert is_logged_in?
   end
 end

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -3,7 +3,9 @@ class UserMailerPreview < ActionMailer::Preview
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/account_activation
   def account_activation
-    UserMailer.account_activation
+    user = User.first
+    user.activation_token = User.new_token
+    UserMailer.account_activation(user)
   end
 
   # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,14 @@
+# Preview all emails at http://localhost:3000/rails/mailers/user_mailer
+class UserMailerPreview < ActionMailer::Preview
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/account_activation
+  def account_activation
+    UserMailer.account_activation
+  end
+
+  # Preview this email at http://localhost:3000/rails/mailers/user_mailer/password_reset
+  def password_reset
+    UserMailer.password_reset
+  end
+
+end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class UserMailerTest < ActionMailer::TestCase
+  test "account_activation" do
+    mail = UserMailer.account_activation
+    assert_equal "Account activation", mail.subject
+    assert_equal ["to@example.org"], mail.to
+    assert_equal ["from@example.com"], mail.from
+    assert_match "Hi", mail.body.encoded
+  end
+
+  test "password_reset" do
+    mail = UserMailer.password_reset
+    assert_equal "Password reset", mail.subject
+    assert_equal ["to@example.org"], mail.to
+    assert_equal ["from@example.com"], mail.from
+    assert_match "Hi", mail.body.encoded
+  end
+
+end

--- a/test/mailers/user_mailer_test.rb
+++ b/test/mailers/user_mailer_test.rb
@@ -2,19 +2,14 @@ require 'test_helper'
 
 class UserMailerTest < ActionMailer::TestCase
   test "account_activation" do
-    mail = UserMailer.account_activation
-    assert_equal "Account activation", mail.subject
-    assert_equal ["to@example.org"], mail.to
-    assert_equal ["from@example.com"], mail.from
-    assert_match "Hi", mail.body.encoded
+    user = users(:michael)
+    user.activation_token = User.new_token
+    mail = UserMailer.account_activation(user)
+    assert_equal "Account activation",    mail.subject
+    assert_equal [user.email],            mail.to
+    assert_equal ["noreply@example.com"], mail.from
+    assert_match user.name,               mail.body.encoded
+    assert_match user.activation_token,   mail.body.encoded
+    assert_match CGI.escape(user.email),  mail.body.encoded
   end
-
-  test "password_reset" do
-    mail = UserMailer.password_reset
-    assert_equal "Password reset", mail.subject
-    assert_equal ["to@example.org"], mail.to
-    assert_equal ["from@example.com"], mail.from
-    assert_match "Hi", mail.body.encoded
-  end
-
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -86,6 +86,6 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "authenticated? should return false for a user with nil digest" do
-    assert_not @user.authenticated?('')
+    assert_not @user.authenticated?(:remember, '')
   end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -88,4 +88,13 @@ class UserTest < ActiveSupport::TestCase
   test "authenticated? should return false for a user with nil digest" do
     assert_not @user.authenticated?(:remember, '')
   end
+
+  test "test should have not activated by default" do
+    assert_not @user.activated?
+  end
+
+  test "test should have activated" do
+    @user.activate
+    assert @user.reload.activated?
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -89,12 +89,15 @@ class UserTest < ActiveSupport::TestCase
     assert_not @user.authenticated?(:remember, '')
   end
 
-  test "test should have not activated by default" do
+  test "activated? should return false by default" do
     assert_not @user.activated?
   end
 
-  test "test should have activated" do
-    @user.activate
-    assert @user.reload.activated?
+  test "should return true when activated" do
+    now = Time.zone.now
+    @user.activate(now)
+    @user.save
+    assert @user.activated?
+    assert_equal now,@user.activated_at
   end
 end


### PR DESCRIPTION
## 背景
Rails Tutorial [第11章](https://railstutorial.jp/chapters/account_activation?version=5.1#cha-account_activation)を無事走りきったので、レビューしていただきたく作成しました。
## やったこと
ユーザー登録の際に、メールによる本人確認の機能を実装しました。これにより、ログインの際、本人確認されていない（有効化されていない）アカウントは、ログインに失敗し、「メールを確認して、アカウントを有効化してください」とフラッシュが出るようになりました。
## メモ
- Action Mailer
  - コントローラーみたいなもの
  - https://railsguides.jp/action_mailer_basics.html
- メソッドの抽象化
  - `#{}_digest` の書き方は流用できそう
- `assigns(:user)`
  - 該当するアプリケーションコード内にあるインスタンス変数を呼び出している...？
  - インスタンス変数の中身を精査したいときに使う
