### PR TITLE
[WIP] Chapter14

### DIFF
--- a/app/assets/javascripts/relationships.coffee
+++ b/app/assets/javascripts/relationships.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -148,6 +148,44 @@ aside {
   margin-top: 15px;
 }
 
+.stats {
+  overflow: auto;
+  margin-top: 0;
+  padding: 0;
+  a {
+    float: left;
+    padding: 0 10px;
+    border-left: 1px solid $gray-lighter;
+    color: gray;
+    &:first-child {
+      padding-left: 0;
+      border: 0;
+    }
+    &:hover {
+      text-decoration: none;
+      color: blue;
+    }
+  }
+  strong {
+    display: block;
+  }
+}
+
+.user_avatars {
+  overflow: auto;
+  margin-top: 10px;
+  .gravatar {
+    margin: 1px 1px;
+  }
+  a {
+    padding: 0;
+  }
+}
+
+.users.follow {
+  padding: 0;
+}
+
 /* forms */
 
 input, textarea, select, .uneditable-input {

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -186,6 +186,12 @@ aside {
   padding: 0;
 }
 
+#follow_form .btn-secondary {
+  background: #cccccc;
+  &:hover {
+    background: #aaaaaa
+  }
+}
 /* forms */
 
 input, textarea, select, .uneditable-input {

--- a/app/assets/stylesheets/relationships.scss
+++ b/app/assets/stylesheets/relationships.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Relationships controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,0 +1,2 @@
+class RelationshipsController < ApplicationController
+end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -16,7 +16,6 @@ class RelationshipsController < ApplicationController
 
   # DELETE /relationships/:id
   def destroy
-    puts params[:followed_id]
     relation = Relationship.find_by(id: params[:id])
     unless relation.nil?
       @user = relation.followed

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -4,7 +4,10 @@ class RelationshipsController < ApplicationController
   # POST /relationships
   def create
     @user = User.find(params[:followed_id])
-    current_user.follow(@user)
+    relation = current_user.follow(@user)
+    unless relation.persisted?
+      flash[:danger] = "Already followed this user"
+    end
     respond_to do |format|
       format.html { redirect_to @user }
       format.js

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -16,10 +16,18 @@ class RelationshipsController < ApplicationController
 
   # DELETE /relationships/:id
   def destroy
-    @user = Relationship.find(params[:id]).followed
-    current_user.unfollow(@user)
+    puts params[:followed_id]
+    relation = Relationship.find_by(id: params[:id])
+    unless relation.nil?
+      @user = relation.followed
+      current_user.unfollow(@user)
+      path = user_path(@user)
+    else
+      flash[:danger] = "Unfollowing users cannot be unfollowed"
+      path = root_path
+    end
     respond_to do |format|
-      format.html { redirect_to @user }
+      format.html { redirect_to path }
       format.js
     end
   end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -1,2 +1,17 @@
 class RelationshipsController < ApplicationController
+  before_action :redirect_unless_logged_in
+
+  # POST /relationships
+  def create
+    user = User.find(params[:followed_id])
+    current_user.follow(user)
+    redirect_to user
+  end
+
+  # DELETE /relationships/:id
+  def destroy
+    user = Relationship.find(params[:id]).followed
+    current_user.unfollow(user)
+    redirect_to user
+  end
 end

--- a/app/controllers/relationships_controller.rb
+++ b/app/controllers/relationships_controller.rb
@@ -3,15 +3,21 @@ class RelationshipsController < ApplicationController
 
   # POST /relationships
   def create
-    user = User.find(params[:followed_id])
-    current_user.follow(user)
-    redirect_to user
+    @user = User.find(params[:followed_id])
+    current_user.follow(@user)
+    respond_to do |format|
+      format.html { redirect_to @user }
+      format.js
+    end
   end
 
   # DELETE /relationships/:id
   def destroy
-    user = Relationship.find(params[:id]).followed
-    current_user.unfollow(user)
-    redirect_to user
+    @user = Relationship.find(params[:id]).followed
+    current_user.unfollow(@user)
+    respond_to do |format|
+      format.html { redirect_to @user }
+      format.js
+    end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
-  before_action :redirect_unless_logged_in, only: [:index, :edit, :update, :destroy]
+  before_action :redirect_unless_logged_in, only: [:index, :edit, :update, :destroy,
+                                                   :following, :followers]
   before_action :correct_user,   only: [:edit, :update]
   before_action :admin_user,     only: :destroy
 
@@ -46,6 +47,20 @@ class UsersController < ApplicationController
     User.find(params[:id]).destroy
     flash[:success] = "User deleted"
     redirect_to users_url
+  end
+
+  def following
+    @title = "Following"
+    @user  = User.find(params[:id])
+    @users = @user.following.paginate(page: params[:page])
+    render 'show_follow'
+  end
+
+  def followers
+    @title = "Followers"
+    @user  = User.find(params[:id])
+    @users = @user.followers.paginate(page: params[:page])
+    render 'show_follow'
   end
 
   private

--- a/app/helpers/relationships_helper.rb
+++ b/app/helpers/relationships_helper.rb
@@ -1,0 +1,2 @@
+module RelationshipsHelper
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,0 +1,2 @@
+class Relationship < ApplicationRecord
+end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,2 +1,4 @@
 class Relationship < ApplicationRecord
+  belongs_to :follower, class_name: 'User'
+  belongs_to :followed, class_name: 'User'
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -1,4 +1,6 @@
 class Relationship < ApplicationRecord
   belongs_to :follower, class_name: 'User'
   belongs_to :followed, class_name: 'User'
+  validates :follower_id, presence: true
+  validates :followed_id, presence: true
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -3,4 +3,5 @@ class Relationship < ApplicationRecord
   belongs_to :followed, class_name: 'User'
   validates :follower_id, presence: true
   validates :followed_id, presence: true
+  validates_uniqueness_of :followed_id, scope: :follower_id
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -81,6 +81,22 @@ class User < ApplicationRecord
     Micropost.where("user_id = ?", self.id)
   end
 
+  # ユーザーをフォローする
+  def follow(other_user)
+    # self は省略できる
+    active_relationships.create(followed_id: other_user.id)
+  end
+
+  # ユーザーをフォロー解除する
+  def unfollow(other_user)
+    active_relationships.find_by(followed_id: other_user.id).destroy
+  end
+
+  # 現在のユーザーがフォローしてたらtrueを返す
+  def following?(other_user)
+    following.include?(other_user)
+  end
+
   private
 
     def downcase_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -82,10 +82,13 @@ class User < ApplicationRecord
     reset_sent_at < 2.hours.ago
   end
 
-  # 試作feedの定義
-  # 次の章で完全体に...!
   def feed
-    Micropost.where("user_id = ?", self.id)
+    following_ids = "SELECT followed_id FROM relationships
+                     WHERE follower_id = :user_id"
+    Micropost.where(
+      "user_id IN (#{following_ids}) OR user_id = :user_id",
+      user_id: self.id
+    )
   end
 
   # ユーザーをフォローする

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,9 @@ class User < ApplicationRecord
       class_name: "Relationship",
      foreign_key: "follower_id",
        dependent: :destroy
+  has_many :following,
+    through: :active_relationships,
+     source: :followed
 
   attr_accessor :remember_token, :activation_token, :reset_token
   before_save   :downcase_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,9 +4,16 @@ class User < ApplicationRecord
       class_name: "Relationship",
      foreign_key: "follower_id",
        dependent: :destroy
+  has_many :passive_relationships,
+      class_name: "Relationship",
+     foreign_key: "followed_id",
+       dependent: :destroy
   has_many :following,
     through: :active_relationships,
      source: :followed
+  has_many :followers,
+    through: :passive_relationships,
+     source: :follower
 
   attr_accessor :remember_token, :activation_token, :reset_token
   before_save   :downcase_email

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,14 @@
 class User < ApplicationRecord
   has_many :microposts, dependent: :destroy
+  has_many :active_relationships,
+      class_name: "Relationship",
+     foreign_key: "follower_id",
+       dependent: :destroy
+
   attr_accessor :remember_token, :activation_token, :reset_token
   before_save   :downcase_email
   before_create :create_activation_digest
+
   validates :name,  presence: true, length: { maximum: 50 }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates :email, presence: true, length: { maximum: 255 },

--- a/app/views/relationships/create.js.erb
+++ b/app/views/relationships/create.js.erb
@@ -1,0 +1,2 @@
+$("#follow_form").html("<%= escape_javascript(render('users/unfollow')) %>");
+$("#followers").html('<%= @user.followers.count %>');

--- a/app/views/relationships/destroy.js.erb
+++ b/app/views/relationships/destroy.js.erb
@@ -1,0 +1,2 @@
+$("#follow_form").html("<%= escape_javascript(render('users/follow')) %>");
+$("#followers").html('<%= @user.followers.count %>');

--- a/app/views/shared/_logged_in_home.html.erb
+++ b/app/views/shared/_logged_in_home.html.erb
@@ -3,6 +3,9 @@
       <section class="user_info">
         <%= render 'shared/user_info' %>
       </section>
+      <section class="stats">
+        <%= render 'shared/stats' %>
+      </section>
       <section class="micropost_form">
         <%= render 'shared/micropost_form' %>
       </section>

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -1,0 +1,15 @@
+<% @user ||= current_user %>
+<div class="stats">
+  <a href="<%= following_user_path(@user) %>">
+    <strong id="following" class="stat">
+      <%= @user.following.count %>
+    </strong>
+    following
+  </a>
+  <a href="<%= followers_user_path(@user) %>">
+    <strong id="followers" class="stat">
+      <%= @user.followers.count %>
+    </strong>
+    followers
+  </a>
+</div>

--- a/app/views/users/_follow.html.erb
+++ b/app/views/users/_follow.html.erb
@@ -1,0 +1,4 @@
+<%= form_with(model: current_user.active_relationships.build, local: true) do |f| %>
+  <div><%= hidden_field_tag :followed_id, @user.id %></div>
+  <%= f.submit "Follow", class: "btn btn-primary" %>
+<% end %>

--- a/app/views/users/_follow.html.erb
+++ b/app/views/users/_follow.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(model: current_user.active_relationships.build, local: true) do |f| %>
+<%= form_with(model: current_user.active_relationships.build) do |f| %>
   <div><%= hidden_field_tag :followed_id, @user.id %></div>
   <%= f.submit "Follow", class: "btn btn-primary" %>
 <% end %>

--- a/app/views/users/_follow_form.html.erb
+++ b/app/views/users/_follow_form.html.erb
@@ -1,0 +1,9 @@
+<% unless current_user?(@user) %>
+  <div id="follow_form">
+  <% if current_user.following?(@user) %>
+    <%= render 'unfollow' %>
+  <% else %>
+    <%= render 'follow' %>
+  <% end %>
+  </div>
+<% end %>

--- a/app/views/users/_unfollow.html.erb
+++ b/app/views/users/_unfollow.html.erb
@@ -1,4 +1,4 @@
 <%= form_with(model: current_user.active_relationships.find_by(followed_id: @user.id),
-             method: :delete, local: true) do |f| %>
+             method: :delete) do |f| %>
   <%= f.submit "Unfollow", class: "btn btn-secondary" %>
 <% end %>

--- a/app/views/users/_unfollow.html.erb
+++ b/app/views/users/_unfollow.html.erb
@@ -1,0 +1,4 @@
+<%= form_with(model: current_user.active_relationships.find_by(followed_id: @user.id),
+             method: :delete, local: true) do |f| %>
+  <%= f.submit "Unfollow", class: "btn btn-secondary" %>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,6 +7,9 @@
         <%= @user.name %>
       </h1>
     </section>
+    <section class="stats">
+        <%= render 'shared/stats' %>
+      </section>
   </aside>
   <div class="col-md-8">
     <% if @user.microposts.any? %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,9 +9,10 @@
     </section>
     <section class="stats">
         <%= render 'shared/stats' %>
-      </section>
+    </section>
   </aside>
   <div class="col-md-8">
+    <%= render 'follow_form' if logged_in? %>
     <% if @user.microposts.any? %>
       <h3>Microposts (<%= @user.microposts.count %>)</h3>
       <ol class="microposts">

--- a/app/views/users/show_follow.html.erb
+++ b/app/views/users/show_follow.html.erb
@@ -1,0 +1,30 @@
+<% provide(:title, @title) %>
+<div class="row">
+  <aside class="col-md-4">
+    <section class="user_info">
+      <%= gravatar_for @user %>
+      <h1><%= @user.name %></h1>
+      <span><%= link_to "view my profile", @user %></span>
+      <span><b>Microposts:</b> <%= @user.microposts.count %></span>
+    </section>
+    <section class="stats">
+      <%= render 'shared/stats' %>
+      <% if @users.any? %>
+        <div class="user_avatars">
+          <% @users.each do |user| %>
+            <%= link_to gravatar_for(user, size: 30), user %>
+          <% end %>
+        </div>
+      <% end %>
+    </section>
+  </aside>
+  <div class="col-md-8">
+    <h3><%= @title %></h3>
+    <% if @users.any? %>
+      <ul class="users follow">
+        <%= render @users %>
+      </ul>
+      <%= will_paginate %>
+    <% end %>
+  </div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,9 +11,7 @@ module SampleApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
 
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
+    # 認証トークンをremoteフォームに埋め込む
+    config.action_view.embed_authenticity_token_in_remote_forms = true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,14 @@ Rails.application.routes.draw do
   get    '/login',   to: 'sessions#new'
   post   '/login',   to: 'sessions#create'
   delete '/logout',  to: 'sessions#destroy'
-  resources :users
+  resources :users do
+    # /users/:id/... ...に何を入れますか?
+    # GET /users/1/following => following action
+    # GET /users/1/followers => followers action
+    member do
+      get :following, :followers
+    end
+  end
   resources :account_activations, only: [:edit]
   resources :password_resets,     only: [:new, :create, :edit, :update]
   resources :microposts,          only: [:create, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,4 +18,5 @@ Rails.application.routes.draw do
   resources :account_activations, only: [:edit]
   resources :password_resets,     only: [:new, :create, :edit, :update]
   resources :microposts,          only: [:create, :destroy]
+  resources :relationships,          only: [:create, :destroy]
 end

--- a/db/migrate/20190829123539_create_relationships.rb
+++ b/db/migrate/20190829123539_create_relationships.rb
@@ -1,0 +1,10 @@
+class CreateRelationships < ActiveRecord::Migration[5.2]
+  def change
+    create_table :relationships do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190829123539_create_relationships.rb
+++ b/db/migrate/20190829123539_create_relationships.rb
@@ -6,5 +6,8 @@ class CreateRelationships < ActiveRecord::Migration[5.2]
 
       t.timestamps
     end
+    add_index :relationships, :follower_id
+    add_index :relationships, :followed_id
+    add_index :relationships, [:follower_id, :followed_id], unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_28_143151) do
+ActiveRecord::Schema.define(version: 2019_08_29_123539) do
 
   create_table "microposts", force: :cascade do |t|
     t.text "content"
@@ -20,6 +20,16 @@ ActiveRecord::Schema.define(version: 2019_08_28_143151) do
     t.string "picture"
     t.index ["user_id", "created_at"], name: "index_microposts_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_microposts_on_user_id"
+  end
+
+  create_table "relationships", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["followed_id"], name: "index_relationships_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_relationships_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_relationships_on_follower_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,3 +27,11 @@ users = User.order(:created_at).take(6)
   content = Faker::Lorem.sentence(word_count: 5)
   users.each { |user| user.microposts.create!(content: content) }
 end
+
+# リレーションシップ
+users = User.all
+user  = User.first
+following = users[2..50]
+followers = users[3..40]
+following.each { |followed| user.follow(followed) }
+followers.each { |follower| follower.follow(user) }

--- a/test/controllers/relationships_controller_test.rb
+++ b/test/controllers/relationships_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RelationshipsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/relationships_controller_test.rb
+++ b/test/controllers/relationships_controller_test.rb
@@ -1,7 +1,17 @@
 require 'test_helper'
 
 class RelationshipsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  test "create should require logged in user" do
+    assert_no_difference 'Relationship.count' do
+      post relationships_path
+    end
+    assert_redirected_to login_url
+  end
+
+  test "destroy should require logged in user" do
+    assert_no_difference 'Relationship.count' do
+      delete relationship_path(relationships(:one))
+    end
+    assert_redirected_to login_url
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -117,4 +117,24 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
       delete user_path(@other_user)
     end
   end
+
+  test "should get following user page when logged in" do
+    log_in_as(@user)
+    get following_user_path(@user)
+  end
+
+  test "should redirect following when not logged in" do
+    get following_user_path(@user)
+    assert_redirected_to login_url
+  end
+
+  test "should get followers page when logged in" do
+    log_in_as(@user)
+    get following_user_path(@user)
+  end
+
+  test "should redirect followers when not logged in" do
+    get followers_user_path(@user)
+    assert_redirected_to login_url
+  end
 end

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,9 +1,0 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-one:
-  follower_id: 1
-  followed_id: 1
-
-two:
-  follower_id: 1
-  followed_id: 1

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,0 +1,15 @@
+one:
+  follower: michael
+  followed: lana
+
+two:
+  follower: michael
+  followed: malory
+
+three:
+  follower: lana
+  followed: michael
+
+four:
+  follower: archer
+  followed: michael

--- a/test/fixtures/relationships.yml
+++ b/test/fixtures/relationships.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  follower_id: 1
+  followed_id: 1
+
+two:
+  follower_id: 1
+  followed_id: 1

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -52,4 +52,11 @@ class FollowingTest < ActionDispatch::IntegrationTest
       delete relationship_path(relationship), xhr: true
     end
   end
+
+  test "feed on Home page" do
+    get root_path
+    @user.feed.paginate(page: 1).each do |micropost|
+      assert_match CGI.escapeHTML(micropost.content), response.body
+    end
+  end
 end

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class FollowingTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:michael)
+    log_in_as(@user)
+  end
+
+  test "following page" do
+    get following_user_path(@user)
+    assert_not @user.following.empty?
+    assert_match @user.following.count.to_s, response.body
+    @user.following.each do |user|
+      assert_select "a[href=?]", user_path(user)
+    end
+  end
+
+  test "followers page" do
+    get followers_user_path(@user)
+    assert_not @user.followers.empty?
+    assert_match @user.followers.count.to_s, response.body
+    @user.followers.each do |user|
+      assert_select "a[href=?]", user_path(user)
+    end
+  end
+end

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -2,7 +2,8 @@ require 'test_helper'
 
 class FollowingTest < ActionDispatch::IntegrationTest
   def setup
-    @user = users(:michael)
+    @user  = users(:michael)
+    @other = users(:archer)
     log_in_as(@user)
   end
 
@@ -21,6 +22,34 @@ class FollowingTest < ActionDispatch::IntegrationTest
     assert_match @user.followers.count.to_s, response.body
     @user.followers.each do |user|
       assert_select "a[href=?]", user_path(user)
+    end
+  end
+
+  test "should follow a user the standard way" do
+    assert_difference '@user.following.count', 1 do
+      post relationships_path, params: { followed_id: @other.id }
+    end
+  end
+
+  test "should follow a user with Ajax" do
+    assert_difference '@user.following.count', 1 do
+      post relationships_path, xhr: true, params: { followed_id: @other.id }
+    end
+  end
+
+  test "should unfollow a user the standard way" do
+    @user.follow(@other)
+    relationship = @user.active_relationships.find_by(followed_id: @other.id)
+    assert_difference '@user.following.count', -1 do
+      delete relationship_path(relationship)
+    end
+  end
+
+  test "should unfollow a user with Ajax" do
+    @user.follow(@other)
+    relationship = @user.active_relationships.find_by(followed_id: @other.id)
+    assert_difference '@user.following.count', -1 do
+      delete relationship_path(relationship), xhr: true
     end
   end
 end

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -31,6 +31,13 @@ class FollowingTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test "should failed when follow again" do
+    @user.follow(@other)
+    assert_no_difference '@user.following.count' do
+      post relationships_path, params: { followed_id: @other.id }
+    end
+  end
+
   test "should follow a user with Ajax" do
     assert_difference '@user.following.count', 1 do
       post relationships_path, xhr: true, params: { followed_id: @other.id }

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -55,8 +55,10 @@ class FollowingTest < ActionDispatch::IntegrationTest
   end
 
   test "should failed unfollow a user not following" do
+    nonexist_id = Relationship.maximum(:id) + 1
+    puts nonexist_id
     assert_no_difference '@user.following.count' do
-      delete relationship_path(id: 999) # nonexist id
+      delete relationship_path(id: nonexist_id)
       assert_not flash[:danger].empty?
       assert_redirected_to root_path
     end

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -28,6 +28,7 @@ class FollowingTest < ActionDispatch::IntegrationTest
   test "should follow a user the standard way" do
     assert_difference '@user.following.count', 1 do
       post relationships_path, params: { followed_id: @other.id }
+      assert_redirected_to user_path(@other)
     end
   end
 
@@ -50,6 +51,14 @@ class FollowingTest < ActionDispatch::IntegrationTest
     relationship = @user.active_relationships.find_by(followed_id: @other.id)
     assert_difference '@user.following.count', -1 do
       delete relationship_path(relationship)
+    end
+  end
+
+  test "should failed unfollow a user not following" do
+    assert_no_difference '@user.following.count' do
+      delete relationship_path(id: 999) # nonexist id
+      assert_not flash[:danger].empty?
+      assert_redirected_to root_path
     end
   end
 

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -56,7 +56,6 @@ class FollowingTest < ActionDispatch::IntegrationTest
 
   test "should failed unfollow a user not following" do
     nonexist_id = Relationship.maximum(:id) + 1
-    puts nonexist_id
     assert_no_difference '@user.following.count' do
       delete relationship_path(id: nonexist_id)
       assert_not flash[:danger].empty?

--- a/test/integration/following_test.rb
+++ b/test/integration/following_test.rb
@@ -35,6 +35,7 @@ class FollowingTest < ActionDispatch::IntegrationTest
     @user.follow(@other)
     assert_no_difference '@user.following.count' do
       post relationships_path, params: { followed_id: @other.id }
+      assert_not flash[:danger].empty?
     end
   end
 

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -1,7 +1,22 @@
 require 'test_helper'
 
 class RelationshipTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  def setup
+    @relationship = Relationship.new(follower_id: users(:michael).id,
+                                     followed_id: users(:archer).id)
+  end
+
+  test "should be valid" do
+    assert @relationship.valid?
+  end
+
+  test "should require a follower_id" do
+    @relationship.follower_id = nil
+    assert_not @relationship.valid?
+  end
+
+  test "should require a followed_id" do
+    @relationship.followed_id = nil
+    assert_not @relationship.valid?
+  end
 end

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class RelationshipTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -2,12 +2,25 @@ require 'test_helper'
 
 class RelationshipTest < ActiveSupport::TestCase
   def setup
-    @relationship = Relationship.new(follower_id: users(:michael).id,
-                                     followed_id: users(:archer).id)
+    @relationship = Relationship.new(
+      follower_id: users(:michael).id,
+      followed_id: users(:archer).id
+    )
   end
 
   test "should be valid" do
     assert @relationship.valid?
+  end
+
+  test "create again same record should be fail" do
+    @invalid_relationship = Relationship.new(
+      follower_id: users(:michael).id,
+      followed_id: users(:archer).id
+    )
+    @relationship.save
+    assert @relationship.persisted?
+    @invalid_relationship.save
+    assert_not @invalid_relationship.persisted?
   end
 
   test "should require a follower_id" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -118,4 +118,14 @@ class UserTest < ActiveSupport::TestCase
       @user.destroy
     end
   end
+
+  test "should follow and unfollow a user" do
+    michael = users(:michael)
+    archer  = users(:archer)
+    assert_not michael.following?(archer)
+    michael.follow(archer)
+    assert michael.following?(archer)
+    michael.unfollow(archer)
+    assert_not michael.following?(archer)
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -129,4 +129,22 @@ class UserTest < ActiveSupport::TestCase
     michael.unfollow(archer)
     assert_not michael.following?(archer)
   end
+
+  test "feed should have the right posts" do
+    michael = users(:michael)
+    archer  = users(:archer)
+    lana    = users(:lana)
+    # フォローしているユーザーの投稿を確認
+    lana.microposts.each do |post_following|
+      assert michael.feed.include?(post_following)
+    end
+    # 自分自身の投稿を確認
+    michael.microposts.each do |post_self|
+      assert michael.feed.include?(post_self)
+    end
+    # フォローしていないユーザーの投稿を確認
+    archer.microposts.each do |post_unfollowed|
+      assert_not michael.feed.include?(post_unfollowed)
+    end
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -125,6 +125,7 @@ class UserTest < ActiveSupport::TestCase
     assert_not michael.following?(archer)
     michael.follow(archer)
     assert michael.following?(archer)
+    assert archer.followers.include?(michael)
     michael.unfollow(archer)
     assert_not michael.following?(archer)
   end


### PR DESCRIPTION
## 背景
RailsTutorial [第14章](https://railstutorial.jp/chapters/following_users?version=5.1#cha-following_users)を無事走りきったので、レビューしていただきたく作成...！

## やったこと
- ユーザー間の関連性を表すモデルの作成
- フォロー関連の統計情報を表示させるパーシャルの作成
- フォロー/フォロー解除ボタンの作成
  - Ajax通信を用いたフォロー/フォロー解除ボタンの実装
- フォロー関連の情報をもとに完全な feed を実装
  - サブクエリによる高速化

## メモ
- `user:references` などは使えない
  - **#{テーブル名}_id** だと、テーブル名を探しに行く
- `add_index`
  - 高速化 
    - フォローしてる人たちの集合を引っ張ってくることが多くなるため
  - 一意性の担保
    - follower_id, followed_id の組み合わせは、常に一意でないといけない
- `belongs_to :follwer, class: 'User'`
  - follower class は存在しないです...でも、代わりに User に紐付けてください
- 全部エラーがでた
  - こういうときは `fixture` を見てみる。テスト用のサンプルデータが間違ってる可能性が...
  - 今回、`test/fixtures/relationships.yml` が大変なことに...
  ```ruby
  one:
    follower_id: 1
    followed_id: 1
  
  two:
    follower_id: 1
    followed_id: 1
  ```
- `following << other_user` == `active_relationships.create(followed_id: other_user.id)`
- routing 周りのtips
```ruby
  resources :users do
    # /users/:id/... ...に何を入れますか?
    # GET /users/1/following => following action
    # GET /users/1/followers => followers action
    member do
      get :following, :followers
    end
  end
```
- has_many の副産物
  - `@user.following.map(&:id)` と書かずに、`@user.following_ids` でフォローしているユーザーのIDを取得できる...
- SQL の世界ではサブセレクトのほうが高速化できるらしい
  - feed の問い合わせだと、書き換えたものは問い合わせが 1回になる
- `CGI.escapeHTML(micropost.content)` CGI.escapeHTML は本当にいるの？？
  - いる。試しにエスケープ処理されてないものを出力してみよう。
  ```
  # escape
  I'm sorry. Your words made sense, but your sarcastic tone did not.
  # no escape
  I&#39;m sorry. Your words made sense, but your sarcastic tone did not.
  ```